### PR TITLE
Melhorando a legibilidade do código

### DIFF
--- a/Capitulo22/Capitulo22_Sobrecarga_de_operadores.ipynb
+++ b/Capitulo22/Capitulo22_Sobrecarga_de_operadores.ipynb
@@ -220,7 +220,7 @@
       "        \"\"\"\n",
       "\n",
       "        i = self.index(xy)\n",
-      "        if not i is None:\n",
+      "        if i is not None:\n",
       "            self.itens.pop(i)\n",
       "        self.itens.append((xy, data))\n",
       "\n",
@@ -248,11 +248,9 @@
       "\n",
       "    def index(self, xy):\n",
       "\n",
-      "        i = 0\n",
-      "        for item in self.itens:\n",
+      "        for i, item in enumerate(self.itens):\n",
       "            if xy == item[0]:\n",
       "                return i\n",
-      "            i += 1\n",
       "        else:\n",
       "            return None\n",
       "\n",
@@ -383,18 +381,11 @@
         "\n",
         "3\u00aa coluna: [0, 1, 2, 3]\n",
         "Fatia com 2\u00aa a 3\u00aa linha [[0, 0, 1], [0, 0, 2]]\n",
-        "Somat\u00f3rio: "
-       ]
-      },
-      {
-       "output_type": "stream",
-       "stream": "stdout",
-       "text": [
-        "11.4 M\u00e9dia 0.95\n"
+        "Somat\u00f3rio: 11.4 M\u00e9dia 0.95\n"
        ]
       }
      ],
-     "prompt_number": 2
+     "prompt_number": 3
     },
     {
      "cell_type": "code",


### PR DESCRIPTION
- Ao invés de usar `not i is None`, usar i is not None.
- Ao invés de usar um contador, usar o enumerate.
